### PR TITLE
Replaced ProgressDialog to ProgressBar.

### DIFF
--- a/app/src/main/java/jp/hotdrop/rtapp/BaseActivity.java
+++ b/app/src/main/java/jp/hotdrop/rtapp/BaseActivity.java
@@ -1,29 +1,10 @@
 package jp.hotdrop.rtapp;
 
-import android.app.ProgressDialog;
 import android.support.v7.app.AppCompatActivity;
 
 import com.google.firebase.auth.FirebaseAuth;
 
 public class BaseActivity extends AppCompatActivity {
-
-    // TODO ProgressDialogはDeprecatedになっているので代替手段を考える
-    private ProgressDialog mProgressDialog;
-
-    public void showProgressDialog() {
-        if (mProgressDialog == null) {
-            mProgressDialog = new ProgressDialog(this);
-            mProgressDialog.setCancelable(false);
-            mProgressDialog.setMessage(getString(R.string.progress_loading));
-        }
-        mProgressDialog.show();
-    }
-
-    public void hideProgressDialog() {
-        if (mProgressDialog != null && mProgressDialog.isShowing()) {
-            mProgressDialog.dismiss();
-        }
-    }
 
     public String getUid() {
         return FirebaseAuth.getInstance().getCurrentUser().getUid();

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -78,4 +78,29 @@
             android:text="@string/sign_up_button" />
 
     </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/progress_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/layout_buttons"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_large" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_normal"
+            android:gravity="center"
+            android:textColor="@color/orange"
+            android:text="@string/progress_loading"/>
+
+    </LinearLayout>
+
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="hint_write_comment">投稿に何かコメントがあれば記載してください。</string>
     <string name="hint_comment_body">ここにコメントを書いてください。</string>
 
-    <string name="progress_loading">ロード中…</string>
+    <string name="progress_loading">ロード中です。しばらくお待ちください。</string>
 
     <!-- Toast message -->
     <string name="toast_sign_in_failure">ログインに失敗しました。</string>


### PR DESCRIPTION
# 概要
ProgressDialogをProgressBarに置き換えた。

# 理由
API26でProgressDialogがdeplecateになり今後は使われなくなるため。
このアプリはAPIレベル20がminVersionのためこのままでもビルドは通るが、ProgressDialogはユーザーの操作を奪ってしまうのでよくない。
なので制御を奪わないProgressBarに置き換えた。